### PR TITLE
Further JOSS tweaks for publication

### DIFF
--- a/docs/paper/paper.bib
+++ b/docs/paper/paper.bib
@@ -27,7 +27,7 @@
 
 @article{astropy,
   title={Astropy: A community {Python} package for astronomy},
-  author={Astropy Collaboration and Robitaille, Thomas P. and Tollerud, Erik J. and Greenfield, Perry and Droettboom, Michael and Bray, Erik and Aldcroft, Tom and Davis, Matt and Ginsburg, Adam and Price-Whelan, Adrian M. and others},
+  author={{Astropy Collaboration} and Robitaille, Thomas P. and Tollerud, Erik J. and Greenfield, Perry and Droettboom, Michael and Bray, Erik and Aldcroft, Tom and Davis, Matt and Ginsburg, Adam and Price-Whelan, Adrian M. and others},
   journal={Astronomy \& Astrophysics},
   volume={558},
   pages={A33},
@@ -44,10 +44,10 @@
 
 @misc{pytest,
   author       = {Holger Krekel and Bruno Oliveira and Ronny Pfannschmidt and Floris Bruynooghe and Brianna Laugher and Florian Bruhin},
-  title        = {pytest 7.4},
+  title        = {{pytest} 7.4},
   year         = {2004},
   howpublished = {\url{https://github.com/pytest-dev/pytest}},
-  note         = {Version x.y. Contributors include Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin, and others.}
+  note         = {Version 7.4. Contributors include Holger Krekel, Bruno Oliveira, Ronny Pfannschmidt, Floris Bruynooghe, Brianna Laugher, Florian Bruhin, and others.}
 }
 
 @Book{h5py,


### PR DESCRIPTION
With my apologies for not picking one of these up earlier, here are just a couple more tweaks for the [JOSS submission](https://github.com/openjournals/joss-reviews/issues/7917). Again, once these are merged I'll do another test run of the publication pipeline.